### PR TITLE
feat: call rejectProofResponse() if ZKPoK fails

### DIFF
--- a/fhevm-engine/transaction-sender/.sqlx/query-472ce6f9493ad23d87b20cd214ba2c9d511d5f39a248f94f7112fb40668f73b7.json
+++ b/fhevm-engine/transaction-sender/.sqlx/query-472ce6f9493ad23d87b20cd214ba2c9d511d5f39a248f94f7112fb40668f73b7.json
@@ -1,6 +1,6 @@
 {
   "db_name": "PostgreSQL",
-  "query": "SELECT zk_proof_id, chain_id, contract_address, user_address, handles\n             FROM verify_proofs\n             WHERE verified = true AND retry_count < $1\n             ORDER BY zk_proof_id\n             LIMIT $2",
+  "query": "SELECT zk_proof_id, chain_id, contract_address, user_address, handles, verified\n             FROM verify_proofs\n             WHERE verified IS NOT NULL AND retry_count < $1\n             ORDER BY zk_proof_id\n             LIMIT $2",
   "describe": {
     "columns": [
       {
@@ -27,6 +27,11 @@
         "ordinal": 4,
         "name": "handles",
         "type_info": "Bytea"
+      },
+      {
+        "ordinal": 5,
+        "name": "verified",
+        "type_info": "Bool"
       }
     ],
     "parameters": {
@@ -40,8 +45,9 @@
       false,
       false,
       false,
+      true,
       true
     ]
   },
-  "hash": "e0664c5a8716c4196090e211fe3e52a68fa94770e4a0e205a92047d8c47775f3"
+  "hash": "472ce6f9493ad23d87b20cd214ba2c9d511d5f39a248f94f7112fb40668f73b7"
 }

--- a/fhevm-engine/transaction-sender/contracts/CiphertextManager.sol
+++ b/fhevm-engine/transaction-sender/contracts/CiphertextManager.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BSD-3-Clause-Clear
 pragma solidity ^0.8.24;
 
-/// @dev This contract is a mock of the CiphertextManager contract from L2.
+/// @dev This contract is a mock of the CiphertextManager contract from the HTTPZ Gateway.
 /// source: github.com/zama-ai/gateway-l2/blob/main/contracts/CiphertextManager.sol
 contract CiphertextManager {
     function addCiphertextMaterial(

--- a/fhevm-engine/transaction-sender/contracts/ZKPoKManager.sol
+++ b/fhevm-engine/transaction-sender/contracts/ZKPoKManager.sol
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: BSD-3-Clause-Clear
 pragma solidity ^0.8.28;
 
+/// @dev This contract is a mock of the ZKPoKManager contract from the HTTPZ Gateway.
+/// source: github.com/zama-ai/gateway-l2/blob/main/contracts/ZKPoKManager.sol
 contract ZKPoKManager {
     event VerifyProofResponseCalled(uint256, bytes32[], bytes);
     event RejectProofResponseCalled(uint256);

--- a/fhevm-engine/transaction-sender/contracts/ZKPoKManager.sol
+++ b/fhevm-engine/transaction-sender/contracts/ZKPoKManager.sol
@@ -3,14 +3,15 @@ pragma solidity ^0.8.28;
 
 contract ZKPoKManager {
     event VerifyProofResponseCalled(uint256, bytes32[], bytes);
+    event RejectProofResponseCalled(uint256);
 
-    error CoprocessorHasAlreadySigned(uint256 zkProofId, address signer);
+    error CoprocessorSignerAlreadyResponded(uint256 zkProofId, address signer);
 
-    bool alreadySignedRevert;
+    bool alreadyRespondedRevert;
     bool generalRevert;
 
-    constructor(bool _alreadySignedRevert, bool _generalRevert) {
-        alreadySignedRevert = _alreadySignedRevert;
+    constructor(bool _alreadyRespondedRevert, bool _generalRevert) {
+        alreadyRespondedRevert = _alreadyRespondedRevert;
         generalRevert = _generalRevert;
     }
 
@@ -23,10 +24,22 @@ contract ZKPoKManager {
             revert("General revert");
         }
 
-        if (alreadySignedRevert) {
-            revert CoprocessorHasAlreadySigned(zkProofId, msg.sender);
+        if (alreadyRespondedRevert) {
+            revert CoprocessorSignerAlreadyResponded(zkProofId, msg.sender);
         }
 
         emit VerifyProofResponseCalled(zkProofId, handles, signature);
+    }
+
+    function rejectProofResponse(uint256 zkProofId) public {
+        if (generalRevert) {
+            revert("General revert");
+        }
+
+        if (alreadyRespondedRevert) {
+            revert CoprocessorSignerAlreadyResponded(zkProofId, msg.sender);
+        }
+
+        emit RejectProofResponseCalled(zkProofId);
     }
 }

--- a/fhevm-engine/transaction-sender/tests/verify_proof_tests.rs
+++ b/fhevm-engine/transaction-sender/tests/verify_proof_tests.rs
@@ -129,7 +129,7 @@ async fn verify_proof_response_success() -> anyhow::Result<()> {
 
 #[tokio::test]
 #[serial(db)]
-async fn verify_proof_response_reversal_already_signed() -> anyhow::Result<()> {
+async fn verify_proof_response_reversal_already_responded() -> anyhow::Result<()> {
     let env = TestEnvironment::new().await?;
     let provider = Arc::new(ProviderBuilder::new().on_anvil_with_wallet());
     let zkpok_manager = ZKPoKManager::deploy(&provider, true, false).await?;
@@ -483,5 +483,301 @@ async fn verify_proof_max_retries_do_not_remove_entry() -> anyhow::Result<()> {
     .await?;
     assert_eq!(rows.len(), 1);
 
+    Ok(())
+}
+
+#[tokio::test]
+#[serial(db)]
+async fn reject_proof_response_success() -> anyhow::Result<()> {
+    let env = TestEnvironment::new().await?;
+    let provider = Arc::new(ProviderBuilder::new().on_anvil_with_wallet());
+    let zkpok_manager = ZKPoKManager::deploy(&provider, false, false).await?;
+    let ciphertext_manager = CiphertextManager::deploy(&provider).await?;
+    let txn_sender = TransactionSender::new(
+        *zkpok_manager.address(),
+        *ciphertext_manager.address(),
+        PrivateKeySigner::random().address(),
+        env.signer.clone(),
+        provider.clone(),
+        env.cancel_token.clone(),
+        env.conf.clone(),
+        None,
+    )
+    .await?;
+
+    let event_filter = zkpok_manager
+        .RejectProofResponseCalled_filter()
+        .watch()
+        .await?;
+
+    let proof_id: u32 = random();
+
+    let run_handle = tokio::spawn(async move { txn_sender.run().await });
+
+    let event_handle = tokio::spawn(async move {
+        event_filter
+            .into_stream()
+            .take(1)
+            .collect::<Vec<_>>()
+            .await
+            .first()
+            .unwrap()
+            .clone()
+            .unwrap()
+    });
+
+    sqlx::query!(
+        "WITH ins AS (
+            INSERT INTO verify_proofs (zk_proof_id, chain_id, contract_address, user_address, handles, verified)
+            VALUES ($1, $2, $3, $4, $5, false)
+        )
+        SELECT pg_notify($6, '')",
+        proof_id as i64,
+        42 as i64,
+        env.contract_address.to_string(),
+        env.user_address.to_string(),
+        &[],
+        env.conf.verify_proof_resp_db_channel
+    )
+    .execute(&env.db_pool)
+    .await?;
+
+    let event = event_handle.await?;
+
+    let expected_proof_id = U256::from(proof_id);
+
+    assert_eq!(event.0._0, expected_proof_id);
+
+    // Make sure the proof is removed from the database.
+    loop {
+        let rows = sqlx::query!(
+            "SELECT *
+             FROM verify_proofs
+             WHERE zk_proof_id = $1",
+            proof_id as i64,
+        )
+        .fetch_all(&env.db_pool)
+        .await?;
+        if rows.is_empty() {
+            break;
+        }
+        sleep(Duration::from_millis(500)).await;
+    }
+
+    env.cancel_token.cancel();
+    run_handle.await??;
+    Ok(())
+}
+
+#[tokio::test]
+#[serial(db)]
+async fn reject_proof_response_reversal_already_responded() -> anyhow::Result<()> {
+    let env = TestEnvironment::new().await?;
+    let provider = Arc::new(ProviderBuilder::new().on_anvil_with_wallet());
+    let zkpok_manager = ZKPoKManager::deploy(&provider, true, false).await?;
+    let ciphertext_manager = CiphertextManager::deploy(&provider).await?;
+    let txn_sender = TransactionSender::new(
+        *zkpok_manager.address(),
+        *ciphertext_manager.address(),
+        PrivateKeySigner::random().address(),
+        env.signer.clone(),
+        provider.clone(),
+        env.cancel_token.clone(),
+        env.conf.clone(),
+        None,
+    )
+    .await?;
+
+    let proof_id: u32 = random();
+
+    let run_handle = tokio::spawn(async move { txn_sender.run().await });
+
+    // Record initial transaction count.
+    let initial_tx_count = provider
+        .get_transaction_count(provider.default_signer_address())
+        .await?;
+
+    sqlx::query!(
+        "WITH ins AS (
+            INSERT INTO verify_proofs (zk_proof_id, chain_id, contract_address, user_address, handles, verified)
+            VALUES ($1, $2, $3, $4, $5, false)
+        )
+        SELECT pg_notify($6, '')",
+        proof_id as i64,
+        42,
+        env.contract_address.to_string(),
+        env.user_address.to_string(),
+        &[],
+        env.conf.verify_proof_resp_db_channel
+    )
+    .execute(&env.db_pool)
+    .await?;
+
+    // Make sure the proof is removed from the database.
+    loop {
+        let rows = sqlx::query!(
+            "SELECT *
+             FROM verify_proofs
+             WHERE zk_proof_id = $1",
+            proof_id as i64,
+        )
+        .fetch_all(&env.db_pool)
+        .await?;
+        if rows.is_empty() {
+            break;
+        }
+        sleep(Duration::from_millis(500)).await;
+    }
+
+    // Verify that no transaction has been sent.
+    let final_tx_count = provider
+        .get_transaction_count(provider.default_signer_address())
+        .await?;
+    assert_eq!(
+        final_tx_count, initial_tx_count,
+        "Expected no new transaction to be sent"
+    );
+
+    env.cancel_token.cancel();
+    run_handle.await??;
+    Ok(())
+}
+
+#[tokio::test]
+#[serial(db)]
+async fn reject_proof_response_other_reversal_receipt() -> anyhow::Result<()> {
+    let env = TestEnvironment::new().await?;
+    let provider = Arc::new(ProviderBuilder::new().on_anvil_with_wallet());
+    let zkpok_manager = ZKPoKManager::deploy(&provider, false, true).await?;
+    let ciphertext_manager = CiphertextManager::deploy(&provider).await?;
+    // Create the sender with a gas limit such that no gas estimation is done, forcing failure at receipt (after the txn has been sent).
+    let txn_sender = TransactionSender::new(
+        *zkpok_manager.address(),
+        *ciphertext_manager.address(),
+        PrivateKeySigner::random().address(),
+        env.signer.clone(),
+        provider.clone(),
+        env.cancel_token.clone(),
+        env.conf.clone(),
+        Some(1_000_000),
+    )
+    .await?;
+
+    let proof_id: u32 = random();
+
+    let run_handle = tokio::spawn(async move { txn_sender.run().await });
+
+    sqlx::query!(
+        "WITH ins AS (
+            INSERT INTO verify_proofs (zk_proof_id, chain_id, contract_address, user_address, handles, verified)
+            VALUES ($1, $2, $3, $4, $5, false)
+        )
+        SELECT pg_notify($6, '')",
+        proof_id as i64,
+        42,
+        env.contract_address.to_string(),
+        env.user_address.to_string(),
+        &[],
+        env.conf.verify_proof_resp_db_channel
+    )
+    .execute(&env.db_pool)
+    .await?;
+
+    // Make sure the proof retry count is incremented.
+    loop {
+        let rows = sqlx::query!(
+            "SELECT *
+             FROM verify_proofs
+             WHERE zk_proof_id = $1",
+            proof_id as i64,
+        )
+        .fetch_all(&env.db_pool)
+        .await?;
+        assert_eq!(rows.len(), 1);
+        if rows.first().unwrap().retry_count > 0 {
+            break;
+        }
+        sleep(Duration::from_millis(500)).await;
+    }
+
+    env.cancel_token.cancel();
+    run_handle.await??;
+
+    // Make sure the entry is removed at the end of the test.
+    sqlx::query("DELETE FROM verify_proofs WHERE zk_proof_id = $1")
+        .bind(proof_id as i64)
+        .execute(&env.db_pool)
+        .await?;
+    Ok(())
+}
+
+#[tokio::test]
+#[serial(db)]
+async fn reject_proof_response_other_reversal_gas_estimation() -> anyhow::Result<()> {
+    let env = TestEnvironment::new().await?;
+    let provider = Arc::new(ProviderBuilder::new().on_anvil_with_wallet());
+    let zkpok_manager = ZKPoKManager::deploy(&provider, false, true).await?;
+    let ciphertext_manager = CiphertextManager::deploy(&provider).await?;
+    let txn_sender = TransactionSender::new(
+        *zkpok_manager.address(),
+        *ciphertext_manager.address(),
+        PrivateKeySigner::random().address(),
+        env.signer.clone(),
+        provider.clone(),
+        env.cancel_token.clone(),
+        env.conf.clone(),
+        None,
+    )
+    .await?;
+
+    let proof_id: u32 = random();
+
+    let run_handle = tokio::spawn(async move { txn_sender.run().await });
+
+    // Insert a proof into the database and notify the sender.
+    sqlx::query!(
+        "WITH ins AS (
+            INSERT INTO verify_proofs (zk_proof_id, chain_id, contract_address, user_address, handles, verified)
+            VALUES ($1, $2, $3, $4, $5, false)
+        )
+        SELECT pg_notify($6, '')",
+        proof_id as i64,
+        42,
+        env.contract_address.to_string(),
+        env.user_address.to_string(),
+        &[],
+        env.conf.verify_proof_resp_db_channel
+    )
+    .execute(&env.db_pool)
+    .await?;
+
+    // Make sure the proof retry count is incremented.
+    //
+    // Note this is a racy test, because the retry count is incremented by the transaction sender and it might
+    // get to a point where retry count reaches max retries - then, transaction sender gives up and deletes the entry.
+    loop {
+        let rows = sqlx::query!(
+            "SELECT *
+             FROM verify_proofs
+             WHERE zk_proof_id = $1",
+            proof_id as i64,
+        )
+        .fetch_all(&env.db_pool)
+        .await?;
+        assert_eq!(rows.len(), 1);
+        if rows.first().unwrap().retry_count > 0 {
+            break;
+        }
+        sleep(Duration::from_millis(500)).await;
+    }
+
+    env.cancel_token.cancel();
+    run_handle.await??;
+
+    // Make sure the entry is removed at the end of the test.
+    sqlx::query("DELETE FROM verify_proofs WHERE zk_proof_id = $1")
+        .bind(proof_id as i64)
+        .execute(&env.db_pool)
+        .await?;
     Ok(())
 }


### PR DESCRIPTION
Resolves: https://github.com/zama-ai/httpz-backend/issues/406

Also, use the `CoprocessorSignerAlreadyResponded` event instead of `CoprocessorHasAlreadySigned` to match the ZKPoKManager contract.