### PR TITLE
fix(txn-sender): concurrent txns 1st step

### DIFF
--- a/fhevm-engine/Cargo.lock
+++ b/fhevm-engine/Cargo.lock
@@ -6792,6 +6792,7 @@ dependencies = [
 name = "test-harness"
 version = "0.1.0"
 dependencies = [
+ "alloy",
  "anyhow",
  "hex",
  "rand 0.9.0",

--- a/fhevm-engine/transaction-sender/src/lib.rs
+++ b/fhevm-engine/transaction-sender/src/lib.rs
@@ -24,6 +24,8 @@ pub struct ConfigSettings {
 
     pub error_sleep_initial_secs: u16,
     pub error_sleep_max_secs: u16,
+
+    pub txn_receipt_timeout_secs: u16,
 }
 
 impl Default for ConfigSettings {
@@ -45,12 +47,23 @@ impl Default for ConfigSettings {
             add_ciphertexts_max_retries: 15,
             allow_handle_batch_limit: 10,
             allow_handle_max_retries: 10,
+            txn_receipt_timeout_secs: 10,
         }
     }
 }
 
+use alloy::providers::fillers::{
+    BlobGasFiller, CachedNonceManager, ChainIdFiller, GasFiller, JoinFill, NonceFiller,
+};
 pub use transaction_sender::TransactionSender;
 
 pub const TXN_SENDER_TARGET: &str = "txn_sender";
 pub const VERIFY_PROOFS_TARGET: &str = "verify_proofs";
 pub const ADD_CIPHERTEXTS_TARGET: &str = "add_ciphertexts";
+
+// Make sure we use a cached nonce manager such that we can send txns concurrently.
+// Note: We take the recommended filler types from the `alloy` crate and just change to a `CachedNonceManager`.
+pub type ProviderFillers = JoinFill<
+    GasFiller,
+    JoinFill<BlobGasFiller, JoinFill<NonceFiller<CachedNonceManager>, ChainIdFiller>>,
+>;

--- a/fhevm-engine/transaction-sender/tests/add_ciphertext_tests.rs
+++ b/fhevm-engine/transaction-sender/tests/add_ciphertext_tests.rs
@@ -5,11 +5,10 @@ use common::{CiphertextManager, TestEnvironment};
 use rand::{random, Rng};
 use serial_test::serial;
 use sqlx::PgPool;
-use std::sync::Arc;
 use std::time::Duration;
 use test_harness::db_utils::insert_random_tenant;
 use tokio::time::sleep;
-use transaction_sender::{ConfigSettings, TransactionSender};
+use transaction_sender::{ConfigSettings, ProviderFillers, TransactionSender};
 
 mod common;
 
@@ -17,7 +16,9 @@ mod common;
 #[serial(db)]
 async fn test_add_ciphertext_digests() -> anyhow::Result<()> {
     let env = TestEnvironment::new().await?;
-    let provider = Arc::new(ProviderBuilder::new().on_anvil_with_wallet());
+    let provider = ProviderBuilder::default()
+        .filler(ProviderFillers::default())
+        .on_anvil_with_wallet();
 
     let ciphertext_manager = CiphertextManager::deploy(&provider).await?;
     let txn_sender = TransactionSender::new(
@@ -119,7 +120,9 @@ async fn test_retry_mechanism() -> anyhow::Result<()> {
     let env = TestEnvironment::new_with_config(conf).await?;
 
     // Create a provider without a wallet.
-    let provider = Arc::new(ProviderBuilder::new().on_anvil());
+    let provider = ProviderBuilder::default()
+        .filler(ProviderFillers::default())
+        .on_anvil();
     let txn_sender = TransactionSender::new(
         PrivateKeySigner::random().address(),
         PrivateKeySigner::random().address(),

--- a/fhevm-engine/transaction-sender/tests/allow_handle.rs
+++ b/fhevm-engine/transaction-sender/tests/allow_handle.rs
@@ -6,11 +6,10 @@ use common::{ACLManager, TestEnvironment};
 use rand::random;
 use serial_test::serial;
 use sqlx::PgPool;
-use std::sync::Arc;
 use std::time::Duration;
 use test_harness::db_utils::insert_random_tenant;
 use tokio::time::sleep;
-use transaction_sender::TransactionSender;
+use transaction_sender::{ProviderFillers, TransactionSender};
 
 mod common;
 
@@ -18,7 +17,9 @@ mod common;
 #[serial(db)]
 async fn test_allow_handle() -> anyhow::Result<()> {
     let env = TestEnvironment::new().await?;
-    let provider = Arc::new(ProviderBuilder::new().on_anvil_with_wallet());
+    let provider = ProviderBuilder::default()
+        .filler(ProviderFillers::default())
+        .on_anvil_with_wallet();
     let acl_manager = ACLManager::deploy(&provider).await?;
 
     let txn_sender = TransactionSender::new(


### PR DESCRIPTION
Use a `CachedNonceManager` instead of the simple one. That allows for concurrent transactions to be sent from the same account.

Add the `txn_receipt_timeout_secs` configuration option to make sure we don't wait for receipts for too long and timeout is configurable.

Note that above solution might not be enough as if some txns fail, say due to not being able to send them to the mempool and the nonce being already incremented, the nonce will be out of sync. One solution is to re-create the provider every time an error occurs. More investigation is needed to see if this is the right approach.