### PR TITLE
fix(txn-sender): use a WS provider instead of HTTP

### DIFF
--- a/fhevm-engine/Cargo.lock
+++ b/fhevm-engine/Cargo.lock
@@ -3135,6 +3135,7 @@ dependencies = [
  "fhevm-engine-common",
  "foundry-compilers",
  "futures-util",
+ "semver 1.0.26",
  "serde",
  "serial_test",
  "sqlx",

--- a/fhevm-engine/fhevm-listener/.gitignore
+++ b/fhevm-engine/fhevm-listener/.gitignore
@@ -1,0 +1,2 @@
+artifacts
+cache

--- a/fhevm-engine/fhevm-listener/Cargo.toml
+++ b/fhevm-engine/fhevm-listener/Cargo.toml
@@ -34,3 +34,4 @@ serial_test = "3.2.0"
 
 [build-dependencies]
 foundry-compilers = { version = "0.13.0", features = ["svm-solc"] }
+semver = "1.0.26"

--- a/fhevm-engine/fhevm-listener/build.rs
+++ b/fhevm-engine/fhevm-listener/build.rs
@@ -1,13 +1,23 @@
-use foundry_compilers::{Project, ProjectPathsConfig};
+use foundry_compilers::{
+    multi::MultiCompiler,
+    solc::{Solc, SolcCompiler},
+    Project, ProjectPathsConfig,
+};
+use semver::Version;
 use std::path::Path;
 fn main() {
     println!("cargo::warning=build.rs run ...");
     let paths =
         ProjectPathsConfig::hardhat(Path::new(env!("CARGO_MANIFEST_DIR")))
             .unwrap();
+    // Use a specific version due to an issue with libc and libstdc++ in the rust Docker image we use to run it.
+    let solc = Solc::find_or_install(&Version::new(0, 8, 28)).unwrap();
     let project = Project::builder()
         .paths(paths)
-        .build(Default::default())
+        .build(
+            MultiCompiler::new(Some(SolcCompiler::Specific(solc)), None)
+                .unwrap(),
+        )
         .unwrap();
     let output = project.compile().unwrap();
     if output.has_compiler_errors() {

--- a/fhevm-engine/gw-listener/src/bin/gw_listener.rs
+++ b/fhevm-engine/gw-listener/src/bin/gw_listener.rs
@@ -57,8 +57,7 @@ async fn main() -> anyhow::Result<()> {
 
     let provider = ProviderBuilder::new()
         .on_ws(WsConnect::new(conf.gw_url.clone()))
-        .await
-        .expect("should have valid provider");
+        .await?;
 
     let cancel_token = CancellationToken::new();
     let gw_listener = GatewayListener::new(

--- a/fhevm-engine/transaction-sender/tests/allow_handle.rs
+++ b/fhevm-engine/transaction-sender/tests/allow_handle.rs
@@ -1,6 +1,6 @@
-use alloy::primitives::Address;
 use alloy::providers::ProviderBuilder;
 use alloy::signers::local::PrivateKeySigner;
+use alloy::{primitives::Address, providers::WsConnect};
 use common::{ACLManager, TestEnvironment};
 
 use rand::random;
@@ -18,8 +18,10 @@ mod common;
 async fn test_allow_handle() -> anyhow::Result<()> {
     let env = TestEnvironment::new().await?;
     let provider = ProviderBuilder::default()
+        .wallet(env.wallet)
         .filler(ProviderFillers::default())
-        .on_anvil_with_wallet();
+        .on_ws(WsConnect::new(env.anvil.ws_endpoint_url()))
+        .await?;
     let acl_manager = ACLManager::deploy(&provider).await?;
 
     let txn_sender = TransactionSender::new(


### PR DESCRIPTION
Since txn-sender waits for txn receipts, it is better to use WS instead of HTTP and polling. This also makes it faster to get the receipts.

Resolves https://github.com/zama-ai/httpz-backend/issues/443