### PR TITLE
feat(txn-sender): nonce management on errors

### DIFF
--- a/fhevm-engine/transaction-sender/src/lib.rs
+++ b/fhevm-engine/transaction-sender/src/lib.rs
@@ -1,3 +1,4 @@
+mod nonce_managed_provider;
 mod ops;
 mod transaction_sender;
 
@@ -26,6 +27,8 @@ pub struct ConfigSettings {
     pub error_sleep_max_secs: u16,
 
     pub txn_receipt_timeout_secs: u16,
+
+    pub required_txn_confirmations: u16,
 }
 
 impl Default for ConfigSettings {
@@ -48,22 +51,15 @@ impl Default for ConfigSettings {
             allow_handle_batch_limit: 10,
             allow_handle_max_retries: 10,
             txn_receipt_timeout_secs: 10,
+            required_txn_confirmations: 0,
         }
     }
 }
 
-use alloy::providers::fillers::{
-    BlobGasFiller, CachedNonceManager, ChainIdFiller, GasFiller, JoinFill, NonceFiller,
-};
+pub use nonce_managed_provider::FillersWithoutNonceManagement;
+pub use nonce_managed_provider::NonceManagedProvider;
 pub use transaction_sender::TransactionSender;
 
 pub const TXN_SENDER_TARGET: &str = "txn_sender";
 pub const VERIFY_PROOFS_TARGET: &str = "verify_proofs";
 pub const ADD_CIPHERTEXTS_TARGET: &str = "add_ciphertexts";
-
-// Make sure we use a cached nonce manager such that we can send txns concurrently.
-// Note: We take the recommended filler types from the `alloy` crate and just change to a `CachedNonceManager`.
-pub type ProviderFillers = JoinFill<
-    GasFiller,
-    JoinFill<BlobGasFiller, JoinFill<NonceFiller<CachedNonceManager>, ChainIdFiller>>,
->;

--- a/fhevm-engine/transaction-sender/src/nonce_managed_provider.rs
+++ b/fhevm-engine/transaction-sender/src/nonce_managed_provider.rs
@@ -1,0 +1,84 @@
+use std::{ops::Deref, sync::Arc};
+
+use alloy::{
+    network::Ethereum,
+    primitives::Address,
+    providers::{
+        fillers::{
+            BlobGasFiller, CachedNonceManager, ChainIdFiller, GasFiller, JoinFill, NonceManager,
+        },
+        PendingTransactionBuilder,
+    },
+    rpc::types::TransactionRequest,
+    transports::TransportResult,
+};
+use futures_util::lock::Mutex;
+
+pub type FillersWithoutNonceManagement =
+    JoinFill<GasFiller, JoinFill<BlobGasFiller, ChainIdFiller>>;
+
+/// A wrapper around an `alloy` provider that sends transactions with the correct nonce.
+/// Note that the given provider by the user must not have nonce management enabled, as this
+/// is done by the `NonceManagedProvider` itself. Users can use the default `FillersWithoutNonceManagement` to create a provider.
+#[derive(Clone)]
+pub struct NonceManagedProvider<P>
+where
+    P: alloy::providers::Provider<Ethereum> + Clone + 'static,
+{
+    provider: P,
+    nonce_manager: Arc<Mutex<CachedNonceManager>>,
+    signer_address: Option<Address>,
+}
+
+impl<P: alloy::providers::Provider<Ethereum> + Clone + 'static> NonceManagedProvider<P> {
+    pub fn new(provider: P, signer_address: Option<Address>) -> Self {
+        Self {
+            provider,
+            nonce_manager: Default::default(),
+            signer_address,
+        }
+    }
+
+    pub async fn send_transaction(
+        &self,
+        tx: impl Into<TransactionRequest>,
+    ) -> TransportResult<PendingTransactionBuilder<Ethereum>> {
+        let mut tx = tx.into();
+        if let Some(signer_address) = self.signer_address {
+            let nonce_manager = self.nonce_manager.lock().await;
+            let nonce = nonce_manager
+                .get_next_nonce(&self.provider, signer_address)
+                .await?;
+            tx.nonce = Some(nonce);
+        }
+        let res = self.provider.send_transaction(tx).await;
+        if res.is_err() {
+            // Reset the nonce manager if the transaction sending failed.
+            *self.nonce_manager.lock().await = Default::default();
+        }
+        res
+    }
+
+    pub async fn get_chain_id(&self) -> TransportResult<u64> {
+        self.provider.get_chain_id().await
+    }
+
+    pub async fn get_transaction_count(&self, address: Address) -> TransportResult<u64> {
+        self.provider.get_transaction_count(address).await
+    }
+
+    pub fn inner(&self) -> &P {
+        &self.provider
+    }
+}
+
+impl<P> Deref for NonceManagedProvider<P>
+where
+    P: alloy::providers::Provider<Ethereum> + Clone + 'static,
+{
+    type Target = P;
+
+    fn deref(&self) -> &Self::Target {
+        &self.provider
+    }
+}

--- a/fhevm-engine/transaction-sender/src/ops/mod.rs
+++ b/fhevm-engine/transaction-sender/src/ops/mod.rs
@@ -1,8 +1,6 @@
 use alloy::network::Ethereum;
 use async_trait::async_trait;
 
-use sqlx::{Pool, Postgres};
-
 #[async_trait]
 pub trait TransactionOperation<P>: Send + Sync
 where
@@ -10,7 +8,7 @@ where
 {
     fn channel(&self) -> &str;
 
-    async fn execute(&self, db_pool: &Pool<Postgres>) -> anyhow::Result<bool>;
+    async fn execute(&self) -> anyhow::Result<bool>;
 }
 
 pub(crate) mod add_ciphertext;

--- a/fhevm-engine/transaction-sender/src/ops/verify_proof.rs
+++ b/fhevm-engine/transaction-sender/src/ops/verify_proof.rs
@@ -1,4 +1,5 @@
 use super::TransactionOperation;
+use crate::nonce_managed_provider::NonceManagedProvider;
 use crate::VERIFY_PROOFS_TARGET;
 use alloy::network::TransactionBuilder;
 use alloy::primitives::{Address, U256};
@@ -34,20 +35,22 @@ sol!(
 #[derive(Clone)]
 pub(crate) struct VerifyProofOperation<P: Provider<Ethereum> + Clone + 'static> {
     zkpok_manager_address: Address,
-    provider: P,
+    provider: NonceManagedProvider<P>,
     signer: PrivateKeySigner,
     conf: crate::ConfigSettings,
     gas: Option<u64>,
     gw_chain_id: u64,
+    db_pool: Pool<Postgres>,
 }
 
 impl<P: alloy::providers::Provider<Ethereum> + Clone + 'static> VerifyProofOperation<P> {
     pub(crate) async fn new(
         zkpok_manager_address: Address,
-        provider: P,
+        provider: NonceManagedProvider<P>,
         signer: PrivateKeySigner,
         conf: crate::ConfigSettings,
         gas: Option<u64>,
+        db_pool: Pool<Postgres>,
     ) -> anyhow::Result<Self> {
         let gw_chain_id = provider.get_chain_id().await?;
         Ok(Self {
@@ -57,27 +60,23 @@ impl<P: alloy::providers::Provider<Ethereum> + Clone + 'static> VerifyProofOpera
             conf,
             gas,
             gw_chain_id,
+            db_pool,
         })
     }
 
-    async fn remove_proof_by_id(
-        &self,
-        db_pool: &Pool<Postgres>,
-        zk_proof_id: i64,
-    ) -> anyhow::Result<()> {
+    async fn remove_proof_by_id(&self, zk_proof_id: i64) -> anyhow::Result<()> {
         debug!(target: VERIFY_PROOFS_TARGET, "Removing proof with id {}", zk_proof_id);
         sqlx::query!(
             "DELETE FROM verify_proofs WHERE zk_proof_id = $1",
             zk_proof_id
         )
-        .execute(db_pool)
+        .execute(&self.db_pool)
         .await?;
         Ok(())
     }
 
     async fn update_retry_count_by_proof_id(
         &self,
-        db_pool: &Pool<Postgres>,
         zk_proof_id: i64,
         error: &str,
     ) -> anyhow::Result<()> {
@@ -92,35 +91,29 @@ impl<P: alloy::providers::Provider<Ethereum> + Clone + 'static> VerifyProofOpera
             zk_proof_id,
             error
         )
-        .execute(db_pool)
+        .execute(&self.db_pool)
         .await?;
         Ok(())
     }
 
-    async fn remove_proofs_by_retry_count(
-        &self,
-        db_pool: &Pool<Postgres>,
-        max_retries: u32,
-    ) -> anyhow::Result<()> {
+    async fn remove_proofs_by_retry_count(&self, max_retries: u32) -> anyhow::Result<()> {
         debug!(target: VERIFY_PROOFS_TARGET, "Removing proof with retry count >= {}", max_retries);
         sqlx::query!(
             "DELETE FROM verify_proofs WHERE retry_count >= $1",
             max_retries as i64
         )
-        .execute(db_pool)
+        .execute(&self.db_pool)
         .await?;
         Ok(())
     }
 
     async fn process_proof(
         &self,
-        db_pool: Pool<Postgres>,
-        provider: P,
         txn_request: (i64, impl Into<TransactionRequest>),
     ) -> anyhow::Result<()> {
         info!(target: VERIFY_PROOFS_TARGET, "Processing proof with proof id {}", txn_request.0);
         let txn_req = txn_request.1.into();
-        let transaction = match provider.send_transaction(txn_req.clone()).await {
+        let transaction = match self.provider.send_transaction(txn_req.clone()).await {
             Ok(txn) => txn,
             Err(e) => {
                 error!(target: VERIFY_PROOFS_TARGET, "Transaction {:?} sending failed with error: {}", txn_req, e);
@@ -129,30 +122,28 @@ impl<P: alloy::providers::Provider<Ethereum> + Clone + 'static> VerifyProofOpera
                     .and_then(|payload| payload.as_decoded_error::<ZKPoKManagerErrors>(true))
                 {
                     info!(target: VERIFY_PROOFS_TARGET, "Coprocessor has already responded, removing proof");
-                    self.remove_proof_by_id(&db_pool, txn_request.0).await?;
+                    self.remove_proof_by_id(txn_request.0).await?;
                     return Ok(());
                 } else {
-                    self.update_retry_count_by_proof_id(&db_pool, txn_request.0, &e.to_string())
+                    self.update_retry_count_by_proof_id(txn_request.0, &e.to_string())
                         .await?;
                     return Err(anyhow::Error::new(e));
                 }
             }
         };
 
-        // TODO: Even though we are sending the txn to a rollup, we need to think about reorgs of the parent chain and,
-        // therefore, potentially change the required confirmations to a value greater than 1.
         let receipt = match transaction
             .with_timeout(Some(Duration::from_secs(
                 self.conf.txn_receipt_timeout_secs as u64,
             )))
-            .with_required_confirmations(1)
+            .with_required_confirmations(self.conf.required_txn_confirmations as u64)
             .get_receipt()
             .await
         {
             Ok(receipt) => receipt,
             Err(e) => {
                 error!(target: VERIFY_PROOFS_TARGET, "Getting receipt failed with error: {}", e);
-                self.update_retry_count_by_proof_id(&db_pool, txn_request.0, &e.to_string())
+                self.update_retry_count_by_proof_id(txn_request.0, &e.to_string())
                     .await?;
                 return Err(anyhow::Error::new(e));
             }
@@ -160,11 +151,11 @@ impl<P: alloy::providers::Provider<Ethereum> + Clone + 'static> VerifyProofOpera
 
         if receipt.status() {
             info!(target: VERIFY_PROOFS_TARGET, "Transaction {} succeeded", receipt.transaction_hash);
-            self.remove_proof_by_id(&db_pool, txn_request.0).await?;
+            self.remove_proof_by_id(txn_request.0).await?;
         } else {
             error!(target: VERIFY_PROOFS_TARGET, "Transaction {} failed with status {}", 
                 receipt.transaction_hash, receipt.status());
-            self.update_retry_count_by_proof_id(&db_pool, txn_request.0, "receipt status = false")
+            self.update_retry_count_by_proof_id(txn_request.0, "receipt status = false")
                 .await?;
             return Err(anyhow::anyhow!(
                 "Transaction {} failed with status {}",
@@ -185,10 +176,10 @@ where
         &self.conf.verify_proof_resp_db_channel
     }
 
-    async fn execute(&self, db_pool: &Pool<Postgres>) -> anyhow::Result<bool> {
-        let zkpok_manager = ZKPoKManager::new(self.zkpok_manager_address, &self.provider);
+    async fn execute(&self) -> anyhow::Result<bool> {
+        let zkpok_manager = ZKPoKManager::new(self.zkpok_manager_address, self.provider.inner());
         if self.conf.verify_proof_remove_after_max_retries {
-            self.remove_proofs_by_retry_count(db_pool, self.conf.verify_proof_resp_max_retries)
+            self.remove_proofs_by_retry_count(self.conf.verify_proof_resp_max_retries)
                 .await?;
         }
         let rows = sqlx::query!(
@@ -200,7 +191,7 @@ where
             self.conf.verify_proof_resp_max_retries as i64,
             self.conf.verify_proof_resp_batch_limit as i64
         )
-        .fetch_all(db_pool)
+        .fetch_all(&self.db_pool)
         .await?;
         info!(target: VERIFY_PROOFS_TARGET, "Selected {} rows to process", rows.len());
         let maybe_has_more_work = rows.len() == self.conf.verify_proof_resp_batch_limit as usize;
@@ -214,7 +205,7 @@ where
                         .ok_or(anyhow::anyhow!("handles field is None"))?;
                     if handles.is_empty() || handles.len() % 32 != 0 {
                         error!(target: VERIFY_PROOFS_TARGET, "Bad handles field, len {} is 0 or not divisible by 32", handles.len());
-                        self.remove_proof_by_id(db_pool, row.zk_proof_id).await?;
+                        self.remove_proof_by_id(row.zk_proof_id).await?;
                         continue;
                     }
                     let handles: Vec<FixedBytes<32>> = handles
@@ -295,14 +286,8 @@ where
                 }
             };
 
-            let db_pool = db_pool.clone();
-            let provider = self.provider.clone();
             let self_clone = self.clone();
-            join_set.spawn(async move {
-                self_clone
-                    .process_proof(db_pool, provider, txn_request)
-                    .await
-            });
+            join_set.spawn(async move { self_clone.process_proof(txn_request).await });
         }
         while let Some(res) = join_set.join_next().await {
             res??;


### PR DESCRIPTION
Since a nonce could be incremented in the `CachedNonceManager` when
transaction sending fails (say due to the GW being down or the
connection to it being lost), in this commit we introduce the
`NonceManagedProvider`. It contains a `CachedNonceManager` inside of it.
In case of any error, we re-create the `CachedNonceManager`, forcing it
to fetch the latest nonce from the GW and start from there. That allows
us to send txns concurrently in a safe way.

Add a configuration option for the required confirmations with a default
value of 0. Reasoning is that we assume the GW to be a rollup and we are
not waiting for hard finality on it.

We also simplify code by putting the DB pool and provider inside of the
the operations data structures.